### PR TITLE
DEVOPS-3429 Add 'Lost connection to MySQL server at' error message family to retryable

### DIFF
--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -60,7 +60,8 @@ module Activerecord::Mysql::Reconnect
     'Access denied for user',
     'The MySQL server is running with the --read-only option',
     'Unknown MySQL server host', # For DNS blips
-    'Communications link failure'
+    'Communications link failure',
+    'Lost connection to MySQL server at'
   ]
 
   HANDLE_ERROR_MESSAGES = HANDLE_R_ERROR_MESSAGES + HANDLE_RW_ERROR_MESSAGES


### PR DESCRIPTION
#### Reviewers: [How to do a Code Review](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/17989636/Code+Review)

#### Deployability of Changes per [Deployment Policy](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/284262558/Deployment+Policy)

- [ ]  3 Required Reviews: 1 peer/buddy + 1 SME from [here](https://docs.google.com/spreadsheets/d/1WDsHrNZKVqM_N8R1_jmM5PGh5MhNrM9SQf03MxLjBmQ) + 1 of your Manager OR Embedded QE
  - [ ]  Migration review obtained from 1 of Becky Bell, Maddy Sullivan, or Andy Chang if this PR contains a migration
  - [ ]  In case of unplanned/emergency deploy, +1 from [Incident Manager](https://cloudpercept.pagerduty.com/schedules#P21BIDY)?
- [ ]  PR title is meaningful and includes JIRA ticket(s) in webhook format, ie. "[ENG-3333] Handle nil case in partner id check"


#### Branch Pointer Testing (do not complete if none was done):
- Link to passing Jenkins build if PR tests are failing due to inter-repo dependencies:

  - 
  - [ ]  Branch pointers in Gemfile removed?

#### Documentation links:

- JIRA Ticket(s): https://cloudhealthtech.atlassian.net/browse/DEVOPS-3429
- Design Doc (where applicable):
- Does this fix a rollbar? If so, provide Rollbar link:
- Does this fix a recently-deployed change? (within past two sprints) 
  - If so, [please complete a miniRCA.](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/1264452916/How+to+complete+a+miniRCA)

#### Proposed changes:
- Add a new match error string to reconnect to catch these flavors of MySQL comm errors
- https://rollbar.com/cloudhealthtech/prod-500s/items/13206/ (not Aurora)
- https://rollbar.com/cloudhealthtech/prod-500s/items/13189/
- Should eliminate more of MySQL2 errors that we see in prod 500s and elsewhere

#### Test Plan and Risk Assessment:
_Will this change impact other teams' code? If so, how?_
- None


_How could this change break? What would be the impact?_
- 
-

_How did you test this locally?_
- Hacked code on webserver eng
2.5.5 :005 > HANDLE_RW_ERROR_MESSAGES = [
    'MySQL server has gone away',
    'Server shutdown in progress',
    'closed MySQL connection',
    "Can't connect to MySQL server",
    "Can't connect to local MySQL server", # When running in local sandbox, or using a socket file
    'Could not create connection to database server',
    'Query execution was interrupted',
    'Access denied for user',
    'The MySQL server is running with the --read-only option',
    'Unknown MySQL server host', # For DNS blips
    'Communications link failure',
    'Lost connection to MySQL server at'
  ]
 => ["MySQL server has gone away", "Server shutdown in progress", "closed MySQL connection", "Can't connect to MySQL server", "Can't connect to local MySQL server", "Could not create connection to database server", "Query execution was interrupted", "Access denied for user", "The MySQL server is running with the --read-only option", "Unknown MySQL server host", "Communications link failure", "Lost connection to MySQL server at"]
2.5.5 :019 >
2.5.5 :020 > Regexp.union(HANDLE_RW_ERROR_MESSAGES) =~ "Lost connection to MySQL server at 'reading initial communication packet', system error: 104"
 => 0

_How will you test this in Labs? Apps? CP-/Cube-Workers in prod?
- Testable in rails console that we did not cause regression
-

_Do your changes handle nil cases where they might be passed in?_
- N/A
-

_Rollback Plan (incl migration backout where necessary):_
- Can be rolled back
-

#### Migration readiness (remove if not applicable):
- [ ]  Did you follow [How to Create a Good Migration](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/10715236/How+To+Create+a+good+migration)?
- [ ] Provide the output of [this command](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/10715236/How+To+Create+a+good+migration#HowToCreateagoodmigration-performance:) for _every table your migration touches_ in a comment on this PR.
- [ ]  Migration tested locally
  - _How long did the migration take to run in your sandbox?_ 
- [ ]  Migrate Down Tested
- [ ]  Timestamp updated to current day/time or day/time of expected deployment
- [ ]  Migration review obtained from 1 of Becky Bell, or Maddy Sullivan, or Andy Chang.
- Other notes:

#### For Terraform readiness (remove if not applicable):
- Please attach the output of Terraform Plan:
-

#### Screenshots (where applicable):
