### PR TITLE
DEVOPS-6047 Retry SSL errors as we get occasional blips from RDS proxy

### DIFF
--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -61,7 +61,8 @@ module Activerecord::Mysql::Reconnect
     'The MySQL server is running with the --read-only option',
     'Unknown MySQL server host', # For DNS blips
     'Communications link failure',
-    'Lost connection to MySQL server at'
+    'Lost connection to MySQL server at',
+    'SSL connection error' # RDS Proxy blips
   ]
 
   HANDLE_ERROR_MESSAGES = HANDLE_R_ERROR_MESSAGES + HANDLE_RW_ERROR_MESSAGES


### PR DESCRIPTION
See https://cloudhealthtech.atlassian.net/browse/DEVOPS-6047 and https://rollbar.com/cloudhealthtech/team-jarvis/items/15243/

Will get deployed to cloudpercept.

Low risk 